### PR TITLE
Workaround for KinD cluster failing to create in GH codespaces

### DIFF
--- a/src/scripts/01-install-kind.sh
+++ b/src/scripts/01-install-kind.sh
@@ -12,7 +12,8 @@ chmod +x ./kind
 sudo mv ./kind /usr/local/bin/kind
 kind --version
 
-# Create KinD cluster
+# Create KinD cluster. See the following GitHub issue for more on why I had to resort to manually creating the docker network: https://github.com/kubernetes-sigs/kind/issues/3748
+docker network create -d=bridge -o com.docker.network.bridge.enable_ip_masquerade=true -o com.docker.network.driver.mtu=1500 --subnet fc00:f853:ccd:e793::/64 kind
 kind create cluster --name otel-target-allocator-talk
 
 # Install kubectl


### PR DESCRIPTION
Adding workaround to address an issue in creating a KinD cluster in GitHub Codespaces. See issue reference https://github.com/kubernetes-sigs/kind/issues/3748.